### PR TITLE
Target extraction without running make

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -6,6 +6,16 @@ import os from 'os';
 import { exec } from 'child_process';
 import voucher from 'voucher';
 
+export const config = {
+  useMake: {
+    title: 'Target extraction with make',
+    description: 'Use `make` to extract targets. This may yield unwanted targets, or take a long time and a lot of resource.',
+    type: 'boolean',
+    default: false,
+    order: 1
+  }
+};
+
 export function provideBuilder() {
   return class MakeBuildProvider {
     constructor(cwd) {
@@ -27,7 +37,11 @@ export function provideBuilder() {
         sh: false
       };
 
-      return voucher(exec, 'make -prRn', { cwd: this.cwd }).then(output => {
+      const promise = atom.config.get('build-make.useMake') ?
+        voucher(exec, 'make -prRn', { cwd: this.cwd }) :
+        voucher(fs.readFile, path.join(this.cwd, 'Makefile'));
+
+      return promise.then(output => {
         return [ defaultTarget ].concat(output.toString('utf8')
           .split(os.EOL)
           .filter(line => /^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/.test(line))

--- a/lib/make.js
+++ b/lib/make.js
@@ -39,10 +39,10 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      return [ 'Makefile', 'GNUmakefile', 'makefile' ]
+      this.files = [ 'Makefile', 'GNUmakefile', 'makefile' ]
         .map(f => path.join(this.cwd, f))
-        .filter(fs.existsSync)
-        .length > 0;
+        .filter(fs.existsSync);
+      return this.files.length > 0;
     }
 
     settings() {
@@ -57,11 +57,11 @@ export function provideBuilder() {
 
       const promise = atom.config.get('build-make.useMake') ?
         voucher(exec, 'make -prRn', { cwd: this.cwd }) :
-        voucher(fs.readFile, path.join(this.cwd, 'Makefile'));
+        voucher(fs.readFile, this.files[0]); // Only take the first file
 
       return promise.then(output => {
         return [ defaultTarget ].concat(output.toString('utf8')
-          .split(os.EOL)
+          .split(/[\r\n]{1,2}/)
           .filter(line => /^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/.test(line))
           .map(targetLine => targetLine.split(':').shift())
           .map(target => ({

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -11,6 +11,7 @@ describe('make', () => {
   const Builder = provideBuilder();
 
   beforeEach(() => {
+    atom.config.set('build-make.useMake', true);
     waitsForPromise(() => {
       return vouch(temp.mkdir, 'atom-build-make-spec-')
         .then((dir) => vouch(fs.realpath, dir))
@@ -48,6 +49,16 @@ describe('make', () => {
           expect(target.exec).toBe('make');
           expect(target.args).toEqual([ 'some_custom' ]);
           expect(target.sh).toBe(false);
+        });
+      });
+    });
+
+    it('should yield a subset of all targets if it does not use make to extract targets', () => {
+      atom.config.set('build-make.useMake', false);
+      waitsForPromise(() => {
+        return Promise.resolve(builder.settings(directory)).then((settings) => {
+          const targetNames = settings.map(s => s.name).sort();
+          expect(targetNames).toEqual([ 'GNU Make: default (no args)', 'GNU Make: all', 'GNU Make: some_custom' ].sort());
         });
       });
     });

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -57,6 +57,7 @@ describe('make', () => {
     it('should yield a subset of all targets if it does not use make to extract targets', () => {
       atom.config.set('build-make.useMake', false);
       waitsForPromise(() => {
+        expect(builder.isEligible(directory)).toBe(true);
         return Promise.resolve(builder.settings(directory)).then((settings) => {
           const targetNames = settings.map(s => s.name).sort();
           expect(targetNames).toEqual([ 'GNU Make: default (no target)', 'GNU Make: all', 'GNU Make: some_custom' ].sort());


### PR DESCRIPTION
Running `make` to get all targets may be quite cumbersome
in both resource and number of yielded targets. Therefore,
an option to allow the user to choose a simpler form of
target extraction which only parses the Makefile as it is.

Directives such as "include" and other derived targets will
not be visisble with this option set (which may very well be
what we want).

Fixes #8
