### PR TITLE
Allow modifying number of jobs

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -5,11 +5,26 @@ import path from 'path';
 import os from 'os';
 import { exec } from 'child_process';
 import voucher from 'voucher';
+import { EventEmitter } from 'events';
+
+export const config = {
+  jobs: {
+    title: 'Simultaneous jobs',
+    description: 'Limits how many jobs make will run simultaneously. Defaults to number of processors. Set to 1 for default behavior of make.',
+    type: 'number',
+    default: os.cpus().length,
+    minimum: 1,
+    maximum: os.cpus().length,
+    order: 1
+  }
+};
 
 export function provideBuilder() {
-  return class MakeBuildProvider {
+  return class MakeBuildProvider extends EventEmitter {
     constructor(cwd) {
+      super();
       this.cwd = cwd;
+      atom.config.observe('build-make.jobs', () => this.emit('refresh'));
     }
 
     getNiceName() {
@@ -21,9 +36,12 @@ export function provideBuilder() {
     }
 
     settings() {
+      const args = [ `-j${atom.config.get('build-make.jobs')}` ];
+
       const defaultTarget = {
         exec: 'make',
-        name: `GNU Make: default (no args)`,
+        name: `GNU Make: default (no target)`,
+        args: args,
         sh: false
       };
 
@@ -34,7 +52,7 @@ export function provideBuilder() {
           .map(targetLine => targetLine.split(':').shift())
           .map(target => ({
             exec: 'make',
-            args: [ target ],
+            args: args.concat([ target ]),
             name: `GNU Make: ${target}`,
             sh: false
           })));

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -11,6 +11,7 @@ describe('make', () => {
   const Builder = provideBuilder();
 
   beforeEach(() => {
+    atom.config.set('build-make.jobs', 2);
     waitsForPromise(() => {
       return vouch(temp.mkdir, 'atom-build-make-spec-')
         .then((dir) => vouch(fs.realpath, dir))
@@ -38,15 +39,15 @@ describe('make', () => {
           expect(settings.length).toBe(4); // default (no args), all, some_custom and Makefile
 
           const defaultTarget = settings[0]; // default MUST be first
-          expect(defaultTarget.name).toBe('GNU Make: default (no args)');
+          expect(defaultTarget.name).toBe('GNU Make: default (no target)');
           expect(defaultTarget.exec).toBe('make');
-          expect(defaultTarget.args).toBe(undefined);
+          expect(defaultTarget.args).toEqual([ '-j2' ]);
           expect(defaultTarget.sh).toBe(false);
 
           const target = settings.find(setting => setting.name === 'GNU Make: some_custom');
           expect(target.name).toBe('GNU Make: some_custom');
           expect(target.exec).toBe('make');
-          expect(target.args).toEqual([ 'some_custom' ]);
+          expect(target.args).toEqual([ '-j2', 'some_custom' ]);
           expect(target.sh).toBe(false);
         });
       });
@@ -74,9 +75,9 @@ describe('make', () => {
           expect(settings.length).toBe(1); // default (no args)
 
           const defaultTarget = settings[0]; // default MUST be first
-          expect(defaultTarget.name).toBe('GNU Make: default (no args)');
+          expect(defaultTarget.name).toBe('GNU Make: default (no target)');
           expect(defaultTarget.exec).toBe('make');
-          expect(defaultTarget.args).toBe(undefined);
+          expect(defaultTarget.args).toEqual([ '-j2' ]);
           expect(defaultTarget.sh).toBe(false);
         });
       });


### PR DESCRIPTION
Make supports running a lot of stuff in parallel by setting
the jobs flag (-j). Do this, and set it to a configurable value
which defaults to the number of cores available on the system.

Fixes #1
