### PR TITLE
Out-of-source builds and (basic) CMake support

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -17,12 +17,26 @@ export const config = {
     maximum: os.cpus().length,
     order: 1
   },
+  buildDir: {
+    title: 'Build directory',
+    description: 'Build directory for out-of-source builds.',
+    type: 'string',
+    default: '.',
+    order: 2
+  },
   useMake: {
     title: 'Target extraction with make',
     description: 'Use `make` to extract targets. This may yield unwanted targets, or take a long time and a lot of resource.',
     type: 'boolean',
     default: false,
-    order: 2
+    order: 3
+  },
+  useCMake: {
+    title: 'Use CMake to generate makefiles',
+    description: 'Use `CMake` to generate makefiles (looks for \'CMakeLists.txt\' in the project or build directory).',
+    type: 'boolean',
+    default: false,
+    order: 4
   }
 };
 
@@ -31,6 +45,7 @@ export function provideBuilder() {
     constructor(cwd) {
       super();
       this.cwd = cwd;
+      this.build_dir = '.';
       atom.config.observe('build-make.jobs', () => this.emit('refresh'));
     }
 
@@ -38,11 +53,28 @@ export function provideBuilder() {
       return 'GNU Make';
     }
 
-    isEligible() {
-      this.files = [ 'Makefile', 'GNUmakefile', 'makefile' ]
-        .map(f => path.join(this.cwd, f))
+    findMakefile() {
+      return [ 'Makefile', 'GNUmakefile', 'makefile' ]
+        .map(f => path.join(this.cwd,f))
+        .concat([ 'Makefile', 'GNUmakefile', 'makefile' ]
+          .map(f => path.join(this.build_dir,f)))
         .filter(fs.existsSync);
-      return this.files.length > 0;
+    }
+
+    findCMakefile() {
+      return [ 'CMakeLists.txt' ]
+        .map(f => path.join(this.cwd,f))
+        .concat([ 'CMakeLists.txt' ]
+          .map(f => path.join(this.build_dir,f)))
+        .filter(fs.existsSync);
+    }
+
+    isEligible() {
+      this.build_dir = path.join(this.cwd,atom.config.get('build-make.buildDir'));
+      this.files = atom.config.get('build-make.useCMake') ?
+        this.findCMakefile() : this.findMakefile();
+      return (this.files.length > 0 &&
+        fs.existsSync(this.build_dir));
     }
 
     settings() {
@@ -55,9 +87,22 @@ export function provideBuilder() {
         sh: false
       };
 
-      const promise = atom.config.get('build-make.useMake') ?
-        voucher(exec, 'make -prRn', { cwd: this.cwd }) :
-        voucher(fs.readFile, this.files[0]); // Only take the first file
+      // TODO: Revise this conditional chaining of promises below.. may not
+      // be the most awesome design, but it's working ;)
+      var promise = Promise.resolve(atom.config.get('build-make.useCMake')).then(
+        useCMake => { return (useCMake ?
+          voucher(exec, 'cmake '.concat(
+            this.build_dir == path.dirname(this.files[0]) ? '.' :
+            path.relative(this.build_dir, path.dirname(this.files[0])) ),
+            { cwd: this.build_dir } )
+            .then( () => {
+              this.files = this.findMakefile();
+              return atom.config.get('build-make.useMake'); } ) :
+          atom.config.get('build-make.useMake')) } );
+
+      promise = promise.then(useMake => { return (useMake ?
+          voucher(exec, 'make -prRn', { cwd: this.build_dir }) :
+          voucher(fs.readFile, this.files[0])) }); // Only take the first file
 
       return promise.then(output => {
         return [ defaultTarget ].concat(output.toString('utf8')
@@ -68,7 +113,8 @@ export function provideBuilder() {
             exec: 'make',
             args: args.concat([ target ]),
             name: `GNU Make: ${target}`,
-            sh: false
+            sh: false,
+            cwd: this.build_dir
           })));
       }).catch(e => [ defaultTarget ]);
     }

--- a/lib/make.js
+++ b/lib/make.js
@@ -55,22 +55,22 @@ export function provideBuilder() {
 
     findMakefile() {
       return [ 'Makefile', 'GNUmakefile', 'makefile' ]
-        .map(f => path.join(this.cwd,f))
+        .map(f => path.join(this.cwd, f))
         .concat([ 'Makefile', 'GNUmakefile', 'makefile' ]
-          .map(f => path.join(this.build_dir,f)))
+          .map(f => path.join(this.build_dir, f)))
         .filter(fs.existsSync);
     }
 
     findCMakefile() {
       return [ 'CMakeLists.txt' ]
-        .map(f => path.join(this.cwd,f))
+        .map(f => path.join(this.cwd, f))
         .concat([ 'CMakeLists.txt' ]
-          .map(f => path.join(this.build_dir,f)))
+          .map(f => path.join(this.build_dir, f)))
         .filter(fs.existsSync);
     }
 
     isEligible() {
-      this.build_dir = path.join(this.cwd,atom.config.get('build-make.buildDir'));
+      this.build_dir = path.join(this.cwd, atom.config.get('build-make.buildDir'));
       this.files = atom.config.get('build-make.useCMake') ?
         this.findCMakefile() : this.findMakefile();
       return (this.files.length > 0 &&
@@ -89,20 +89,24 @@ export function provideBuilder() {
 
       // TODO: Revise this conditional chaining of promises below.. may not
       // be the most awesome design, but it's working ;)
-      var promise = Promise.resolve(atom.config.get('build-make.useCMake')).then(
-        useCMake => { return (useCMake ?
-          voucher(exec, 'cmake '.concat(
-            this.build_dir == path.dirname(this.files[0]) ? '.' :
-            path.relative(this.build_dir, path.dirname(this.files[0])) ),
-            { cwd: this.build_dir } )
+      let promise = Promise.resolve(atom.config.get('build-make.useCMake'))
+        .then(useCMake => {
+          const cmakeCmd = 'cmake '.concat(
+            this.build_dir === path.dirname(this.files[0]) ?
+            '.' : path.relative(this.build_dir, path.dirname(this.files[0])) );
+          return (useCMake ? voucher(exec, cmakeCmd, { cwd: this.build_dir } )
             .then( () => {
               this.files = this.findMakefile();
-              return atom.config.get('build-make.useMake'); } ) :
-          atom.config.get('build-make.useMake')) } );
+              return atom.config.get('build-make.useMake');
+            } ) :
+          atom.config.get('build-make.useMake') );
+        } );
 
-      promise = promise.then(useMake => { return (useMake ?
+      promise = promise.then(useMake => {
+        return (useMake ?
           voucher(exec, 'make -prRn', { cwd: this.build_dir }) :
-          voucher(fs.readFile, this.files[0])) }); // Only take the first file
+          voucher(fs.readFile, this.files[0]) );
+      } ); // Only take the first file
 
       return promise.then(output => {
         return [ defaultTarget ].concat(output.toString('utf8')


### PR DESCRIPTION
Currently, Makefiles must reside in the project root folder and make is always executed in this folder.
It would be a great if we could support out-of-source builds.

For the out-of-source builds, I implemented the following changes:
- Additional config item 'Build Directory' (path relative to the project root, defaults to '.')
- Search for Makefiles is performed in both, the project root and the build directory
- Make is run from within the build directory (which defaults to the project root, but may be altered)

Out-of-source build support enables to easily support CMake Makefile generation:
- Another config item 'Use CMake' (True/False)
- If enabled, CMake input file (CMakeLists.txt) is searched first and CMake is executed 
- The Makefiile generated by CMake is then found and make can be run as before

This was the first time in a while that I got in touch with Javascript and I had to wrap my head around the concept of Promises to include the additional (and conditional) call to execute CMake before Make. I think, I got it right and it does work, but there is a little TODO marking the section that I would like to have reviewed by someone who knows what he's doing ;).
Also, I haven't added any unittests yet, as I'm completely unfamiliar with the atom testing framework.
