### PR TITLE
Add a regex to catch ocaml errors

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -27,8 +27,10 @@ export const config = {
 };
 
 export function provideBuilder() {
+  const gccErrorMatch = '(?<file>[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)';
+  const ocamlErrorMatch = '(?<file>[\\/0-9a-zA-Z\\._\\-]+)", line (?<line>\\d+), characters (?<col>\\d+)-(?<col_end>\\d+):\\n(?<message>.+)';
   const errorMatch = [
-    '(?<file>[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)'
+    gccErrorMatch, ocamlErrorMatch
   ];
 
   return class MakeBuildProvider extends EventEmitter {


### PR DESCRIPTION
OCaml compilers (`ocamlc`/`ocamlopt`) provide warnings and errors with this schema:

```
File "foo/bar.ml", line 277, characters 12-13:
Warning 26: unused variable g.
File "foo/bar.ml", line 280, characters 6-64:
Warning 34: unused type t.
File "foo/bar.ml", line 279, characters 0-6:
Error: Syntax error
```

I added a regex to `errorMatch` to catch those warnings and errors.
