### PR TITLE
Fix gcc regular expression to also work with windows paths

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -27,7 +27,7 @@ export const config = {
 };
 
 export function provideBuilder() {
-  const gccErrorMatch = '(?<file>[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)';
+  const gccErrorMatch = '(?<file>([A-Z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)';
   const ocamlErrorMatch = '(?<file>[\\/0-9a-zA-Z\\._\\-]+)", line (?<line>\\d+), characters (?<col>\\d+)-(?<col_end>\\d+):\\n(?<message>.+)';
   const errorMatch = [
     gccErrorMatch, ocamlErrorMatch

--- a/lib/make.js
+++ b/lib/make.js
@@ -27,7 +27,7 @@ export const config = {
 };
 
 export function provideBuilder() {
-  const gccErrorMatch = '(?<file>([A-Z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)';
+  const gccErrorMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)';
   const ocamlErrorMatch = '(?<file>[\\/0-9a-zA-Z\\._\\-]+)", line (?<line>\\d+), characters (?<col>\\d+)-(?<col_end>\\d+):\\n(?<message>.+)';
   const errorMatch = [
     gccErrorMatch, ocamlErrorMatch


### PR DESCRIPTION
Absolute paths on windows start with a drive letter. Without this patch,
an error message like

```
C:/blah/blah.cpp:10:6 ....
```

will only match `/blah/blah.cpp` as a file path, and we are not able to
jump to the source code from the error.

Edit: Oh, and I did not touch the ocaml regexp because I can't test it 
easily but it probably has the same problem.
