### PR TITLE
Added "build" as package-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "eslint": "^1.10.1",
     "eslint-config-atom-build": "^2.0.0"
   },
+  "package-deps": [
+    "build"
+  ],
   "keywords": [
     "build",
     "compile",


### PR DESCRIPTION
Taken example from https://github.com/noseglid/atom-build/blob/master/package.json#L30

This should ensure installation of "build" package whenever you install "build-make"
