### PR TITLE
Separate warnings from errors in GCC output

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -61,11 +61,11 @@ export function provideBuilder() {
 
       const defaultTarget = {
         exec: 'make',
-        name: `GNU Make: default (no target)`,
+        name: 'GNU Make: default (no target)',
         args: args,
         sh: false,
         errorMatch: errorMatch,
-        warningMatch: warningMatch,
+        warningMatch: warningMatch
       };
 
       const promise = atom.config.get('build-make.useMake') ?
@@ -83,7 +83,7 @@ export function provideBuilder() {
             name: `GNU Make: ${target}`,
             sh: false,
             errorMatch: errorMatch,
-            warningMatch: warningMatch,
+            warningMatch: warningMatch
           })));
       }).catch(e => [ defaultTarget ]);
     }

--- a/lib/make.js
+++ b/lib/make.js
@@ -27,10 +27,15 @@ export const config = {
 };
 
 export function provideBuilder() {
-  const gccErrorMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error|warning):\\s*(?<message>.+)';
+  const gccErrorMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error):\\s*(?<message>.+)';
   const ocamlErrorMatch = '(?<file>[\\/0-9a-zA-Z\\._\\-]+)", line (?<line>\\d+), characters (?<col>\\d+)-(?<col_end>\\d+):\\n(?<message>.+)';
   const errorMatch = [
     gccErrorMatch, ocamlErrorMatch
+  ];
+
+  const gccWarningMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(warning):\\s*(?<message>.+)';
+  const warningMatch = [
+    gccWarningMatch
   ];
 
   return class MakeBuildProvider extends EventEmitter {
@@ -59,7 +64,8 @@ export function provideBuilder() {
         name: `GNU Make: default (no target)`,
         args: args,
         sh: false,
-        errorMatch: errorMatch
+        errorMatch: errorMatch,
+        warningMatch: warningMatch,
       };
 
       const promise = atom.config.get('build-make.useMake') ?
@@ -76,7 +82,8 @@ export function provideBuilder() {
             args: args.concat([ target ]),
             name: `GNU Make: ${target}`,
             sh: false,
-            errorMatch: errorMatch
+            errorMatch: errorMatch,
+            warningMatch: warningMatch,
           })));
       }).catch(e => [ defaultTarget ]);
     }


### PR DESCRIPTION
This is a very small change.
It uses `atom-build` ability to specify warningMatcher(s).

Any feedback appreciated.
