### PR TITLE
No recursion when extracting targets from Makefile

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -70,7 +70,7 @@ export function provideBuilder() {
       };
 
       const promise = atom.config.get('build-make.useMake') ?
-        voucher(exec, 'make -prRn', { cwd: this.cwd }) :
+        voucher(exec, 'MAKE=true make -prRn', { cwd: this.cwd }) :
         voucher(fs.readFile, this.files[0]); // Only take the first file
 
       return promise.then(output => {


### PR DESCRIPTION
Using the MAKE variable in a recipe makes the recipe execute
regardless of the -n option. Temporarily override this variable
when extracting targets so that the `$(MAKE)` call does nothing.

This is useful for example when building drivers against the
linux kernel. The database printed by `make -prRn` is so big
it leads to this plugin not proposing any targets.

Note that this is a sane way to deal with this.
What I mean by that is that if the plugin was handling
"normally" the resulting huge database, then there would be
a great number of extra _invalid_ targets listed. So this allows
the plugin to output something when using big recursive
Makefiles _and_ ensures that targets that are not available
at the current level are not proposed.

As far as I'm aware this does not eliminate valid targets from
the proposal list.

I first tried with `MAKE= make -prRn`, but then make would
complain about the command not being valid and again, no
plugin output. Using `true` ensures that every recursive returns
immediately and happily.

Another solution would be to use `make -w` and to count the
`make[n]: entering directory ...` and corresponding 
`make[n]: leaving directory ...` lines, but I don't know of a case 
where this would give a more correct output.
