### PR TITLE
add golang regex error support

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -29,8 +29,9 @@ export const config = {
 export function provideBuilder() {
   const gccErrorMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(fatal error|error):\\s*(?<message>.+)';
   const ocamlErrorMatch = '(?<file>[\\/0-9a-zA-Z\\._\\-]+)", line (?<line>\\d+), characters (?<col>\\d+)-(?<col_end>\\d+):\\n(?<message>.+)';
+  const golangErrorMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):\\s*(?<message>.*error.+)';
   const errorMatch = [
-    gccErrorMatch, ocamlErrorMatch
+    gccErrorMatch, ocamlErrorMatch, golangErrorMatch
   ];
 
   const gccWarningMatch = '(?<file>([A-Za-z]:[\\/])?[^:\\n]+):(?<line>\\d+):(?<col>\\d+):\\s*(warning):\\s*(?<message>.+)';


### PR DESCRIPTION
Add error matching for golang errors.

This fix is probably much broader than golang : <file>:<line>:.*error.+
