### PR TITLE
Bear integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@
 Uses the [atom-build](https://github.com/noseglid/atom-build) package to execute
 GNU make in the `Atom` editor.
 
+When [Bear](https://github.com/rizsotto/Bear) is installed, uses it to generate a compilation database for clang tooling.
+
 This package requires [atom-build](https://github.com/noseglid/atom-build) to be installed.

--- a/lib/make.js
+++ b/lib/make.js
@@ -6,7 +6,7 @@ import os from 'os';
 import { exec } from 'child_process';
 import voucher from 'voucher';
 import { EventEmitter } from 'events';
-import hasbin from 'hasbin'
+import hasbin from 'hasbin';
 
 export const config = {
   jobs: {
@@ -84,7 +84,7 @@ export function provideBuilder() {
         voucher(fs.readFile, this.files[0]); // Only take the first file
 
       return promise.then(output => {
-        const returntargets = [ defaultTarget ].concat(output.toString('utf8')
+        let returntargets = [ defaultTarget ].concat(output.toString('utf8')
           .split(/[\r\n]{1,2}/)
           .filter(line => /^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/.test(line))
           .map(targetLine => targetLine.split(':').shift())
@@ -98,18 +98,18 @@ export function provideBuilder() {
             warningMatch: warningMatch
           })));
 
-          if (atom.config.get('build-make.useBear') && hasbin.sync('bear')) {
-            return returntargets.concat({
-              exec: `make clean && bear make -j${atom.config.get('build-make.jobs')}`,
-              name: 'GNU Make: generate compile_commands.json (with bear)',
-              args: [],
-              sh: true,
-              errorMatch: errorMatch,
-              warningMatch: warningMatch
-            });
-          } else {
-            return returntargets;
-          }
+        if (atom.config.get('build-make.useBear') && hasbin.sync('bear')) {
+          returntargets = returntargets.concat({
+            exec: `make clean && bear make -j${atom.config.get('build-make.jobs')}`,
+            name: 'GNU Make: generate compile_commands.json (with bear)',
+            args: [],
+            sh: true,
+            errorMatch: errorMatch,
+            warningMatch: warningMatch
+          });
+        }
+
+        return returntargets;
       }).catch(e => [ defaultTarget ]);
     }
   };

--- a/lib/make.js
+++ b/lib/make.js
@@ -101,7 +101,7 @@ export function provideBuilder() {
         if (atom.config.get('build-make.useBear') && hasbin.sync('bear')) {
           returntargets = returntargets.concat({
             exec: `make clean && bear make -j${atom.config.get('build-make.jobs')}`,
-            name: 'GNU Make: generate compile_commands.json (with bear)',
+            name: 'BEAR: compile_commands.json',
             args: [],
             sh: true,
             errorMatch: errorMatch,

--- a/lib/make.js
+++ b/lib/make.js
@@ -27,7 +27,7 @@ export const config = {
   },
   useBear: {
     title: 'Bear integration',
-    description: 'If present, use `bear` to generate compile_commands.json',
+    description: 'If present, add `bear` target to generate compile_commands.json',
     type: 'boolean',
     default: true,
     order: 3
@@ -68,12 +68,10 @@ export function provideBuilder() {
     }
 
     settings() {
-      const buildexec = atom.config.get('build-make.useBear') && hasbin.sync('bear') ? 'bear' : 'make';
-
-      const args = atom.config.get('build-make.useBear') && hasbin.sync('bear') ? [`make`, `-j${atom.config.get('build-make.jobs')}`] : [`-j${atom.config.get('build-make.jobs')}`];
+      const args = [`-j${atom.config.get('build-make.jobs')}`];
 
       const defaultTarget = {
-        exec: buildexec,
+        exec: 'make',
         name: 'GNU Make: default (no target)',
         args: args,
         sh: false,
@@ -86,19 +84,32 @@ export function provideBuilder() {
         voucher(fs.readFile, this.files[0]); // Only take the first file
 
       return promise.then(output => {
-        return [ defaultTarget ].concat(output.toString('utf8')
+        const returntargets = [ defaultTarget ].concat(output.toString('utf8')
           .split(/[\r\n]{1,2}/)
           .filter(line => /^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/.test(line))
           .map(targetLine => targetLine.split(':').shift())
           .filter( (elem, pos, array) => (array.indexOf(elem) === pos) )
           .map(target => ({
-            exec: buildexec,
+            exec: 'make',
             args: args.concat([ target ]),
             name: `GNU Make: ${target}`,
             sh: false,
             errorMatch: errorMatch,
             warningMatch: warningMatch
           })));
+
+          if (atom.config.get('build-make.useBear') && hasbin.sync('bear')) {
+            return returntargets.concat({
+              exec: `make clean && bear make -j${atom.config.get('build-make.jobs')}`,
+              name: 'GNU Make: generate compile_commands.json (with bear)',
+              args: [],
+              sh: true,
+              errorMatch: errorMatch,
+              warningMatch: warningMatch
+            });
+          } else {
+            return returntargets;
+          }
       }).catch(e => [ defaultTarget ]);
     }
   };

--- a/lib/make.js
+++ b/lib/make.js
@@ -6,6 +6,7 @@ import os from 'os';
 import { exec } from 'child_process';
 import voucher from 'voucher';
 import { EventEmitter } from 'events';
+import hasbin from 'hasbin'
 
 export const config = {
   jobs: {
@@ -23,6 +24,13 @@ export const config = {
     type: 'boolean',
     default: false,
     order: 2
+  },
+  useBear: {
+    title: 'Bear integration',
+    description: 'If present, use `bear` to generate compile_commands.json',
+    type: 'boolean',
+    default: true,
+    order: 3
   }
 };
 
@@ -44,6 +52,8 @@ export function provideBuilder() {
       super();
       this.cwd = cwd;
       atom.config.observe('build-make.jobs', () => this.emit('refresh'));
+      atom.config.observe('build-make.useMake', () => this.emit('refresh'));
+      atom.config.observe('build-make.useBear', () => this.emit('refresh'));
     }
 
     getNiceName() {
@@ -58,10 +68,12 @@ export function provideBuilder() {
     }
 
     settings() {
-      const args = [ `-j${atom.config.get('build-make.jobs')}` ];
+      const buildexec = atom.config.get('build-make.useBear') && hasbin.sync('bear') ? 'bear' : 'make';
+
+      const args = atom.config.get('build-make.useBear') && hasbin.sync('bear') ? [`make`, `-j${atom.config.get('build-make.jobs')}`] : [`-j${atom.config.get('build-make.jobs')}`];
 
       const defaultTarget = {
-        exec: 'make',
+        exec: buildexec,
         name: 'GNU Make: default (no target)',
         args: args,
         sh: false,
@@ -80,7 +92,7 @@ export function provideBuilder() {
           .map(targetLine => targetLine.split(':').shift())
           .filter( (elem, pos, array) => (array.indexOf(elem) === pos) )
           .map(target => ({
-            exec: 'make',
+            exec: buildexec,
             args: args.concat([ target ]),
             name: `GNU Make: ${target}`,
             sh: false,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   ],
   "main": "lib/make.js",
   "dependencies": {
+    "hasbin": "^1.2.3",
+    "minimatch": "^3.0.3",
     "voucher": "^0.1.2"
   }
 }

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -13,6 +13,7 @@ describe('make', () => {
   beforeEach(() => {
     atom.config.set('build-make.useMake', true);
     atom.config.set('build-make.jobs', 2);
+    atom.config.set('build-make.useBear', false)
     waitsForPromise(() => {
       return vouch(temp.mkdir, 'atom-build-make-spec-')
         .then((dir) => vouch(fs.realpath, dir))

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import temp from 'temp';
 import { vouch } from 'atom-build-spec-helpers';
 import { provideBuilder } from '../lib/make';
-import hasbin from 'hasbin'
+import hasbin from 'hasbin';
 
 describe('make', () => {
   let directory;
@@ -14,7 +14,7 @@ describe('make', () => {
   beforeEach(() => {
     atom.config.set('build-make.useMake', true);
     atom.config.set('build-make.jobs', 2);
-    atom.config.set('build-make.useBear', false)
+    atom.config.set('build-make.useBear', false);
     waitsForPromise(() => {
       return vouch(temp.mkdir, 'atom-build-make-spec-')
         .then((dir) => vouch(fs.realpath, dir))
@@ -134,7 +134,7 @@ describe('make', () => {
       it('should add a new "generate compile_commands.json" target', () => {
         waitsForPromise(() => {
           return Promise.resolve(builder.settings(directory)).then((settings) => {
-            const target = settings[settings.length-1];
+            const target = settings[settings.length - 1];
 
             expect(target.name).toBe('GNU Make: generate compile_commands.json (with bear)');
             expect(target.exec).toBe('make clean && bear make -j2');

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -118,4 +118,21 @@ describe('make', () => {
       expect(builder.isEligible(directory)).toBe(false);
     });
   });
+
+  describe('when bear integration is enabled', () => {
+    beforeEach(() => {
+      atom.config.set('build-make.useBear', true);
+    });
+
+    it('should run it and add `make` as an argument', () => {
+      waitsForPromise(() => {
+        return Promise.resolve(builder.settings(directory)).then((settings) => {
+          const defaultTarget = settings[0]; // default MUST be first
+
+          expect(defaultTarget.exec).toBe('bear');
+          expect(defaultTarget.args).toEqual([ 'make', '-j2' ]);
+        });
+      });
+    });
+  });
 });

--- a/spec/build-make-spec.js
+++ b/spec/build-make-spec.js
@@ -136,7 +136,7 @@ describe('make', () => {
           return Promise.resolve(builder.settings(directory)).then((settings) => {
             const target = settings[settings.length - 1];
 
-            expect(target.name).toBe('GNU Make: generate compile_commands.json (with bear)');
+            expect(target.name).toBe('BEAR: compile_commands.json');
             expect(target.exec).toBe('make clean && bear make -j2');
             expect(target.args).toEqual([]);
             expect(target.sh).toBe(true);
@@ -153,7 +153,7 @@ describe('make', () => {
       it('should not create a new target', () => {
         waitsForPromise(() => {
           return Promise.resolve(builder.settings(directory)).then((settings) => {
-            const target = settings.find(setting => setting.name === 'GNU Make: generate compile_commands.json (with bear)');
+            const target = settings.find(setting => setting.name === 'BEAR: compile_commands.json');
 
             expect(target).toBeUndefined();
           });


### PR DESCRIPTION
This change enables anyone using [bear](https://github.com/rizsotto/Bear) to run it as a new target.

The option is enabled by default in the settings, because if build-make doesn't find `bear` binary in the path, it simply doesn't run it and goes back to the default `make` command.

I updated `minimatch` dependency too, in order to avoid this message during `npm install`:

> npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

![screen](https://cloud.githubusercontent.com/assets/10487071/25073126/d89695ec-22df-11e7-9ebb-5b5ed5e13064.png)
